### PR TITLE
Fixes needed for Visual Studio 2022 preview 17.3.2

### DIFF
--- a/VisualStudioMac.SolutionTreeFilter/Constants.cs
+++ b/VisualStudioMac.SolutionTreeFilter/Constants.cs
@@ -2,7 +2,7 @@
 {
     public static class Constants
     {
-        internal const string Version = "17.3.0";
+        internal const string Version = "17.3.1";
         internal const string SolutionFilterPadId = "VisualStudioMac.SolutionTreeFilter.Gui.FilterPad";
     }
 }

--- a/VisualStudioMac.SolutionTreeFilter/Gui/FilterPad.cs
+++ b/VisualStudioMac.SolutionTreeFilter/Gui/FilterPad.cs
@@ -88,7 +88,7 @@ namespace VisualStudioMac.SolutionTreeFilter.Gui
                         return;
 
                     if (sender is Workbench wb)
-                        sender = wb.RootWindow;
+                        sender = wb.Window;
 
                     var activeWorkbenchWindowProp = sender.GetType().GetProperty("ActiveWorkbenchWindow");
                     var activeWorkbenchWindow = activeWorkbenchWindowProp.GetValue(sender, null);

--- a/VisualStudioMac.SolutionTreeFilter/Gui/FilterPadWidget.UI.cs
+++ b/VisualStudioMac.SolutionTreeFilter/Gui/FilterPadWidget.UI.cs
@@ -44,7 +44,7 @@ namespace VisualStudioMac.SolutionTreeFilter.Gui
                 VerticalPlacement = WidgetPlacement.Center,
             };
 
-            filterClearButton = new Button(ImageService.GetIcon("gtk-delete", Gtk.IconSize.Button))
+            filterClearButton = new Button(ImageService.GetIcon("gtk-delete", Xwt.IconSize.Small))
             {
                 MarginLeft = 0,
                 MarginRight = 2,
@@ -54,7 +54,7 @@ namespace VisualStudioMac.SolutionTreeFilter.Gui
                 Style = ButtonStyle.Borderless,
                 TooltipText = "Clear"
             };
-            var refreshButton = new Button(ImageService.GetIcon("gtk-refresh", Gtk.IconSize.Menu))
+            var refreshButton = new Button(ImageService.GetIcon("gtk-refresh", Xwt.IconSize.Small))
             {
                 MarginLeft = 0,
                 MarginRight = 6,
@@ -124,7 +124,7 @@ namespace VisualStudioMac.SolutionTreeFilter.Gui
 
             // Expand projects section
             var buttonsHBox = new HBox();
-            pinOpenDocumentsButton = new Button(ImageService.GetIcon(Stock.PinDown, Gtk.IconSize.Button), "Pin All Open Docs")
+            pinOpenDocumentsButton = new Button(ImageService.GetIcon(Stock.PinDown, Xwt.IconSize.Small), "Pin All Open Docs")
             {
                 MarginLeft = 6,
                 MarginRight = 2,
@@ -132,7 +132,7 @@ namespace VisualStudioMac.SolutionTreeFilter.Gui
                 HorizontalPlacement = WidgetPlacement.Center,
             };
 
-            resetPinnedButton = new Button(ImageService.GetIcon(Stock.PinUp, Gtk.IconSize.Button), "Unpin All")
+            resetPinnedButton = new Button(ImageService.GetIcon(Stock.PinUp, Xwt.IconSize.Small), "Unpin All")
             {
                 MarginLeft = 2,
                 MarginRight = 6,

--- a/VisualStudioMac.SolutionTreeFilter/Properties/AddinInfo.cs
+++ b/VisualStudioMac.SolutionTreeFilter/Properties/AddinInfo.cs
@@ -1,6 +1,7 @@
 ﻿using Mono.Addins;
 using Mono.Addins.Description;
 using VisualStudioMac.SolutionTreeFilter;
+using System.Runtime.Versioning;
 
 [assembly: Addin(
     "SolutionTreeFilter",
@@ -17,3 +18,5 @@ using VisualStudioMac.SolutionTreeFilter;
 [assembly: AddinDependency("::MonoDevelop.Core", MonoDevelop.BuildInfo.Version)]
 [assembly: AddinDependency("::MonoDevelop.Ide", MonoDevelop.BuildInfo.Version)]
 [assembly: AddinDependency("::MonoDevelop.TextEditor", MonoDevelop.BuildInfo.Version)]
+
+[assembly: SupportedOSPlatform("macos10.15")]

--- a/VisualStudioMac.SolutionTreeFilter/VisualStudioMac.SolutionTreeFilter.csproj
+++ b/VisualStudioMac.SolutionTreeFilter/VisualStudioMac.SolutionTreeFilter.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
@@ -18,5 +18,15 @@
 			<HintPath>\Applications\Visual Studio %28Preview%29.app\Contents\MonoBundle\Xamarin.Mac.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="Xwt">
+		  <HintPath>..\..\..\..\..\Applications\Visual Studio %28Preview%29.app\Contents\MonoBundle\Xwt.dll</HintPath>
+		</Reference>
+		<Reference Include="Xwt.XamMac">
+		  <HintPath>..\..\..\..\..\Applications\Visual Studio %28Preview%29.app\Contents\MonoBundle\Xwt.XamMac.dll</HintPath>
+		</Reference>
+	</ItemGroup>
+	<ItemGroup>
+	  <None Remove="Xwt" />
+	  <None Remove="Xwt.XamMac" />
 	</ItemGroup>
 </Project>

--- a/pack.sh
+++ b/pack.sh
@@ -1,14 +1,24 @@
 #!/bin/sh
 clear
 
+# Get and goto folder of this script's location
 SCRIPTFILE=$0
-
-#Get the absolute path to the containing folder
 PROJECTFOLDER=${SCRIPTFILE%/*}
-
 cd ${PROJECTFOLDER}
+PROJECTFOLDER=$(pwd)
 
-pwd
-
+# Clean
 rm *.mpack
+
+# Pack
 mono /Applications/Visual\ Studio.app/Contents/Resources/lib/monodevelop/bin/vstool.exe setup pack ./VisualStudioMac.SolutionTreeFilter/bin/VisualStudioMac.SolutionTreeFilter.dll
+
+# Uninstall
+/Applications/Visual\ Studio\ \(Preview\).app/Contents/MacOS/vstool setup uninstall VisualStudioMac.SolutionTreeFilter -y
+
+# Install
+for filename in *.mpack;
+do
+  echo "$filename"
+  /Applications/Visual\ Studio\ \(Preview\).app/Contents/MacOS/vstool setup install "$PROJECTFOLDER/$filename" -y
+done


### PR DESCRIPTION
Fixes needed for Visual Studio 2022 preview 17.3.2
- Update pack.sh
- Reference Xwt
- fix obsolete usage
- fix Gtk size references
- Bump version 17.3.1